### PR TITLE
fix: automatic refreshing on home page

### DIFF
--- a/lib/pages/goods/home/controller.dart
+++ b/lib/pages/goods/home/controller.dart
@@ -21,7 +21,7 @@ class HomeController extends GetxController {
 
   // 刷新控制器
   final RefreshController refreshController = RefreshController(
-    initialRefresh: true,
+    initialRefresh: false,
   );
   // 页码
   int _page = 1;
@@ -93,9 +93,6 @@ class HomeController extends GetxController {
     Storage().setJson(Constants.storageHomeCategories, categoryItems);
     Storage().setJson(Constants.storageHomeFlashSell, flashShellProductList);
     Storage().setJson(Constants.storageHomeNewSell, newProductProductList);
-
-    // 模拟网络延迟 1 秒
-    await Future.delayed(const Duration(seconds: 1));
 
     update(["home"]);
 

--- a/lib/pages/goods/product_list/controller.dart
+++ b/lib/pages/goods/product_list/controller.dart
@@ -41,10 +41,10 @@ class ProductListController extends GetxController {
       // 页数+1
       _page++;
 
+      items.clear();
       // 添加数据
       items.addAll(result);
-      items.addAll(result);
-      items.addAll(result);
+
     }
 
     // 是否空


### PR DESCRIPTION
Now the refreshing function is working as expected: the main page should only refresh when the user intentionally pulls down to refresh the content. 

<img width="308" alt="截屏2023-10-01 19 38 31" src="https://github.com/JoyfulTechLauncher/joyfulfashionista_app_beta/assets/90823176/3f49fc72-aefb-4677-a5f5-1a8a8c375f1d">



I also fixed a minor bug regarding the product display. 
Click the "See All" button on the home page. Now the product can be displayed correctly.


<img width="297" alt="截屏2023-10-01 19 43 46" src="https://github.com/JoyfulTechLauncher/joyfulfashionista_app_beta/assets/90823176/dbb712a3-42c1-4468-8e86-6f27ab851a05">

<img width="294" alt="截屏2023-10-01 19 44 13" src="https://github.com/JoyfulTechLauncher/joyfulfashionista_app_beta/assets/90823176/67a95b79-5442-4cc2-ba68-83181b898938">


