### PR TITLE
feat: categorized products retrieved previously can be saved in cache

### DIFF
--- a/lib/common/api/product.dart
+++ b/lib/common/api/product.dart
@@ -55,10 +55,10 @@ class ProductApi {
 
   static Future<Map<String, List<ProductModel>>> categorizeProducts() async {
 
+    Map<String, List<ProductModel>> categoryProducts = {};
+
     List<CategoryModel> _categories = await categories();
     List<ProductModel> _products = await getProducts();
-
-    Map<String, List<ProductModel>> categoryProducts = {};
 
     for (var _ in _categories) {
       categoryProducts[_.id.toString()!] = [];
@@ -69,6 +69,12 @@ class ProductApi {
           categoryProducts[category.id.toString()]!.add(productModel);
         }
     }
+
+    for (var categoryId in categoryProducts.keys) {
+      List<ProductModel> categoryItems = categoryProducts[categoryId.toString()]!;
+      Storage().setJson(Constants.storageCategorizedProduct + categoryId.toString(), categoryItems);
+    }
+
     return categoryProducts;
   }
 

--- a/lib/common/values/constants.dart
+++ b/lib/common/values/constants.dart
@@ -5,6 +5,7 @@ class Constants {
   static const wcEndpointBaseUrl = '/wp-json/wc/v3';
   static const jwtEndpointUrl = '/jwt-auth/v1/token';
   static const List<String> categoryList = ['Man', 'Woman', 'Children', 'Inclusive', 'Accessories', 'Shipping', 'Popular'];
+
   // 本地存储key
   static const storageLanguageCode = 'language_code';
   static const storageThemeCode = 'theme_code';
@@ -32,8 +33,10 @@ class Constants {
   // 性别
   static const storageProductsAttributesGender = 'products_attributes_gender';
   // 新旧
-  static const storageProductsAttributesCondition =
-      'products_attributes_condition';
+  static const storageProductsAttributesCondition = 'products_attributes_condition';
+  // 分类后的产品清单
+  static const storageCategorizedProduct = "category_";
+
 
   // 首页离线
   static const storageHomeBanner = 'home_banner';


### PR DESCRIPTION
Implemented methods to ensure that previously retrieved categories and categorized products can be saved to the cache and can be displayed correctly.

<img width="308" alt="截屏2023-10-01 20 07 29" src="https://github.com/JoyfulTechLauncher/joyfulfashionista_app_beta/assets/90823176/dd42bf06-c972-481b-8b30-77bab34dbbab">
